### PR TITLE
OSC Listener and Sender

### DIFF
--- a/DS4Windows/DS4Forms/MainWindow.xaml.cs
+++ b/DS4Windows/DS4Forms/MainWindow.xaml.cs
@@ -213,28 +213,7 @@ namespace DS4WinWPF.DS4Forms
 
                     if (launch)
                     {
-                        using (Process p = new Process())
-                        {
-                            p.StartInfo.FileName = Path.Combine(Global.exedirpath, "DS4Updater.exe");
-                            bool isAdmin = Global.IsAdministrator();
-                            List<string> argList = new List<string>();
-                            argList.Add("-autolaunch");
-                            if (!isAdmin)
-                            {
-                                argList.Add("-user");
-                            }
-
-                            // Specify current exe to have DS4Updater launch
-                            argList.Add("--launchExe");
-                            argList.Add(Global.exeFileName);
-
-                            p.StartInfo.Arguments = string.Join(" ", argList);
-                            if (Global.AdminNeeded())
-                                p.StartInfo.Verb = "runas";
-
-                            try { launch = p.Start(); }
-                            catch (InvalidOperationException) { }
-                        }
+                        launch = mainWinVM.LauchDS4Updater();
                     }
 
                     if (launch)

--- a/DS4Windows/DS4Forms/MainWindow.xaml.cs
+++ b/DS4Windows/DS4Forms/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ using HttpProgress;
 using DS4WinWPF.DS4Forms.ViewModels;
 using DS4Windows;
 using DS4WinWPF.Translations;
+using H.NotifyIcon.Core;
 
 namespace DS4WinWPF.DS4Forms
 {
@@ -93,6 +94,7 @@ namespace DS4WinWPF.DS4Forms
 
             trayIconVM = new TrayIconViewModel(App.rootHub, profileListHolder);
             notifyIcon.DataContext = trayIconVM;
+            notifyIcon.CustomName = Global.exelocation;
 
             if (Global.StartMinimized || parser.Mini)
             {

--- a/DS4Windows/DS4Forms/ViewModels/MainWindowsViewModel.cs
+++ b/DS4Windows/DS4Forms/ViewModels/MainWindowsViewModel.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading.Tasks;
 using HttpProgress;
 using DS4Windows;
+using System.Collections.Generic;
 
 namespace DS4WinWPF.DS4Forms.ViewModels
 {
@@ -126,6 +127,35 @@ namespace DS4WinWPF.DS4Forms.ViewModels
                 }
                 catch { }
             }
+        }
+
+        public bool LauchDS4Updater()
+        {
+            bool launch = false;
+            using (Process p = new Process())
+            {
+                p.StartInfo.FileName = Path.Combine(Global.exedirpath, "DS4Updater.exe");
+                bool isAdmin = Global.IsAdministrator();
+                List<string> argList = new List<string>();
+                argList.Add("-autolaunch");
+                if (!isAdmin)
+                {
+                    argList.Add("-user");
+                }
+
+                // Specify current exe to have DS4Updater launch
+                argList.Add("--launchExe");
+                argList.Add(Global.exeFileName);
+
+                p.StartInfo.Arguments = string.Join(" ", argList);
+                if (Global.AdminNeeded())
+                    p.StartInfo.Verb = "runas";
+
+                try { launch = p.Start(); }
+                catch (InvalidOperationException) { }
+            }
+
+            return launch;
         }
     }
 }

--- a/DS4Windows/DS4WinWPF.csproj
+++ b/DS4Windows/DS4WinWPF.csproj
@@ -73,7 +73,7 @@
   <ItemGroup>
     <PackageReference Include="bloomtom.HttpProgress" Version="2.3.2" />
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />
-    <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.53" />
+    <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.58" />
     <PackageReference Include="MdXaml" Version="1.15.0" />
     <PackageReference Include="NLog" Version="5.0.1" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />


### PR DESCRIPTION
Adds an OSC front to DS4Windows. It lets you press buttons and tilt analog sticks on any controller through OSC. I did this for my Twitch chat to mess around with my controller on stream. Also added an OSC sender to send controller activity (buttons, sticks, battery, and plug) to control other things on the network and/or display by browser source on OBS.

Listening OSC Addresses all start with "/ds4windows/[controller]". [controller] is an int between 0-3 with 0 being player 1.

Send OSC to buttons: addr: "/ds4windows/[controller]/press" args: int (1 or 0)
Note: triggers will be treated as buttons. When pressed, they will be set to 255.

Send OSC to sticks: addr: "/ds4windows/[controller]/stick" args: float [x, y] (0.0 - 1.0)

Note: Sticks origin is at the top-left so 0.0 is up and 1.0 is down.

Check the Send Realtime Data box to send your controller inputs to OSC. Button, stick, battery, and plug activity will be sent!

For sending addresses, we have [controller] (int 0-3).
[button] is a DS4 button in lowercase like "cross" or "options"
[trigger] is a DS4 trigger like "l2" or "r2"
[axis] is a stick and its axis like "lx", "ly", "rx", or "ry"

For buttons: addr: "/ds4windows/monitor/[controller]/[button]" args: int (1 or 0)
For triggers: addr: "/ds4windows/monitor/[controller]/[trigger]" args: int (0 - 255)
For sticks: addr: "/ds4windows/monitor/[controller]/[axis]" args: int (0 - 255)